### PR TITLE
fix: remote js-redirect

### DIFF
--- a/src/next.web/wwwroot/js/handler.js
+++ b/src/next.web/wwwroot/js/handler.js
@@ -311,8 +311,11 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 const httpsRedirect = () => {
+    return;
+    /*
     if (location.protocol !== 'https:')
         location.replace('https://' + location.href.split('//')[1]);
+    */
 };
 
 httpsRedirect();


### PR DESCRIPTION
Application site is not accesible over https.
Temporary rollback of https redirect