### PR TITLE
PR | Reader | Folder mapping

### DIFF
--- a/src/processor/next.processor.api/utility/EnvironmentHelper.cs
+++ b/src/processor/next.processor.api/utility/EnvironmentHelper.cs
@@ -4,8 +4,8 @@
     {
         public static string? GetHomeFolder()
         {
-            var home = Environment.GetEnvironmentVariable("HOME");
-            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var home = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
+            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create);
             if (!string.IsNullOrEmpty(home)) return home;
             if (!string.IsNullOrEmpty(local)) return local;
             return null;

--- a/src/processor/next.processor.api/utility/EnvironmentHelper.cs
+++ b/src/processor/next.processor.api/utility/EnvironmentHelper.cs
@@ -1,14 +1,43 @@
-﻿namespace next.processor.api.utility
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace next.processor.api.utility
 {
     public static class EnvironmentHelper
     {
         public static string? GetHomeFolder()
         {
-            var home = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
-            var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create);
+            var home = GetHomeOrDefault();
+            var local = GetAppOrDefault();
             if (!string.IsNullOrEmpty(home)) return home;
             if (!string.IsNullOrEmpty(local)) return local;
             return null;
+        }
+        [ExcludeFromCodeCoverage]
+        private static string? GetHomeOrDefault()
+        {
+            try
+            {
+                var home = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
+                return home;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static string? GetAppOrDefault()
+        {
+            try
+            {
+                var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create);
+                return local;
+            }
+            catch
+            {
+                return string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
## Context  
When attempting to install resources, environment folders are returning an empty string.

### Correction:
As corrective measure adding default attributes to create folder resource when missing.