### PR TITLE
PR | Reader | Update Component

### DIFF
--- a/src/processor/next.processor.api.tests/web/ProgramExtensionTests.cs
+++ b/src/processor/next.processor.api.tests/web/ProgramExtensionTests.cs
@@ -89,7 +89,7 @@ namespace next.processor.api.tests
         {
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             // expected value for queue initializers
-            int expected = isWindows ? 5 : 7;
+            int expected = isWindows ? 4 : 6;
             var provider = GetServiceProvider();
             var service = provider.GetService<IQueueExecutor>();
             Assert.NotNull(service);

--- a/src/processor/next.processor.api/app_data/app_data.txt
+++ b/src/processor/next.processor.api/app_data/app_data.txt
@@ -1,3 +1,4 @@
 application data files are created in app_data folder.
 update data to trigger app deplyment
 update reader component
+update reader component

--- a/src/processor/next.processor.api/app_data/app_data.txt
+++ b/src/processor/next.processor.api/app_data/app_data.txt
@@ -1,2 +1,3 @@
 application data files are created in app_data folder.
 update data to trigger app deplyment
+update reader component

--- a/src/processor/next.processor.api/backing/QueueExecutor.cs
+++ b/src/processor/next.processor.api/backing/QueueExecutor.cs
@@ -179,7 +179,6 @@ namespace next.processor.api.backing
         private static readonly List<string> _installNames = [
             "linux-firefox",
             "linux-geckodriver",
-            "verification",
             "read-collin",
             "read-denton",
             "read-harris",


### PR DESCRIPTION
## Context
During system test, web drivers are unable to execute with error message:

```
An error occurred trying to start process '../geckodriver' with working directory '../current'. 
Permission denied
```

### Correction
- attempting to add driver location to env PATH variable, which is expected to grant execute permission for that folder location.